### PR TITLE
fix(lint): wrap About banner text to drop unescaped apostrophe

### DIFF
--- a/app/aboutScreen.tsx
+++ b/app/aboutScreen.tsx
@@ -8,7 +8,7 @@ export default function AboutScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.text} numberOfLines={1} accessibilityRole="text">
-        SDSU Maps · tap a pin to see what's happening on campus
+        {"SDSU Maps · tap a pin to see what's happening on campus"}
       </Text>
     </View>
   );


### PR DESCRIPTION
## Summary
Two-line fix for the `react/no-unescaped-entities` error left in
`app/aboutScreen.tsx` from the original Track C UI polish PR. Wrapping
the banner string in `{...}` makes the apostrophe a JS string literal
character (no entity escape needed) — same rendered output.

## Scope
- `app/aboutScreen.tsx` line 11: text wrapped in `{}` expression.
- No copy change, no behavior change.
- Does NOT touch the unrelated warning in `app/pinDetails.tsx` (Talan's
  track) — that's a separate cleanup.

## Verification
- `npm run lint` after fix: **0 errors**, 1 warning (the pinDetails one,
  pre-existing).
- `npx tsc --noEmit`: clean.

Closes #28
