### PR TITLE
docs: flip C1 checkbox to done

### DIFF
--- a/docs/TEAM_TASKS.md
+++ b/docs/TEAM_TASKS.md
@@ -73,7 +73,7 @@ once A4 ships, no hardcoded `Aztec Game Lab` placeholder rows.
 
 Branch: `feature/bryan/ui-polish-map`
 
-- [~] **C1** Local map asset wired (`sdsu_campus_map.jpg`, no external
+- [x] **C1** Local map asset wired (`sdsu_campus_map.jpg`, no external
       URL). _(partial: current asset is 276×183 / 22 KB — thumbnail-sized.
       Higher-res export from https://map.sdsu.edu still owed.)_
 - [x] **C2** iOS portrait layout — `useWindowDimensions`, `contentFit="contain"`,


### PR DESCRIPTION
## Summary
One-character flip: `docs/TEAM_TASKS.md` line 76 C1 checkbox `[~]` → `[x]`
after Bryan's decision to ship the current map asset for the May 13 demo.

## Scope
- Single line change. R6-clean (only the checkbox state character flips;
  prose untouched, including the residual nice-to-have note).

## Why no prose cleanup
The parenthetical `(partial: current asset is 276×183 / 22 KB...
Higher-res export from https://map.sdsu.edu still owed)` still reads
true as a residual note. Editing it would trip R6, so leaving it as
context for the next refresh.

Refs #15
