### PR TITLE
A3 + A4 — addEvent and getActiveEvents Firestore service

### DIFF
--- a/app/components/AddEventModal.tsx
+++ b/app/components/AddEventModal.tsx
@@ -1,7 +1,6 @@
 // Polished Add Event modal: labeled fields, inline validation, double-submit
-// guard, unmount-safe async, success/failure feedback. addEvent is stubbed
-// here until Brandon's eventService.ts lands; swap addEventStub for the real
-// import when it does.
+// guard, unmount-safe async, success/failure feedback. Posts to Firestore
+// via app/services/eventService.ts (A3).
 import { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -14,9 +13,12 @@ import {
   View,
   useWindowDimensions,
 } from "react-native";
+import { addEvent } from "../services/eventService";
 import { colors, radius, spacing, tap, typography } from "../constants/theme";
 
-export type EventInput = {
+// Form state holds the raw text-input strings. The service expects parsed
+// Date objects — we convert at the submit boundary.
+type EventFormState = {
   title: string;
   description: string;
   location: string;
@@ -25,9 +27,9 @@ export type EventInput = {
   endDate: string;
 };
 
-type FieldErrors = Partial<Record<keyof EventInput, string>>;
+type FieldErrors = Partial<Record<keyof EventFormState, string>>;
 
-const EMPTY_FORM: EventInput = {
+const EMPTY_FORM: EventFormState = {
   title: "",
   description: "",
   location: "",
@@ -45,7 +47,7 @@ function parseDate(s: string): Date | null {
   return isNaN(d.getTime()) ? null : d;
 }
 
-function validate(form: EventInput): FieldErrors {
+function validate(form: EventFormState): FieldErrors {
   const errors: FieldErrors = {};
   const title = form.title.trim();
   if (!title) errors.title = "Required";
@@ -74,12 +76,6 @@ function validate(form: EventInput): FieldErrors {
   return errors;
 }
 
-// TODO(brandon): replace with real addEvent() from app/services/eventService.ts.
-async function addEventStub(_payload: EventInput): Promise<string> {
-  await new Promise((r) => setTimeout(r, 600));
-  return `stub-${Date.now()}`;
-}
-
 type Props = {
   visible: boolean;
   onClose: () => void;
@@ -89,7 +85,7 @@ export default function AddEventModal({ visible, onClose }: Props) {
   const { width, height } = useWindowDimensions();
   const isLandscape = width > height;
 
-  const [form, setForm] = useState<EventInput>(EMPTY_FORM);
+  const [form, setForm] = useState<EventFormState>(EMPTY_FORM);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -103,7 +99,7 @@ export default function AddEventModal({ visible, onClose }: Props) {
     };
   }, []);
 
-  function update<K extends keyof EventInput>(key: K, value: EventInput[K]) {
+  function update<K extends keyof EventFormState>(key: K, value: EventFormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
     // Clear that field's error as soon as the user types again.
     if (errors[key]) setErrors((prev) => ({ ...prev, [key]: undefined }));
@@ -130,7 +126,18 @@ export default function AddEventModal({ visible, onClose }: Props) {
 
     setSubmitting(true);
     try {
-      await addEventStub(form);
+      // Form-level validate() above already proved these parse, so the
+      // non-null assertions are safe. Service does its own sanity check.
+      const startTime = parseDate(form.startDate)!;
+      const endTime = parseDate(form.endDate)!;
+      await addEvent({
+        title: form.title,
+        description: form.description,
+        location: form.location,
+        clubName: form.clubName,
+        startTime,
+        endTime,
+      });
       if (!mountedRef.current) return;
       Alert.alert("Event added", "Your event has been posted.");
       reset();
@@ -146,7 +153,7 @@ export default function AddEventModal({ visible, onClose }: Props) {
 
   // Borders go red only after an attempted submit, so users aren't yelled
   // at while still filling in the form.
-  function showError(key: keyof EventInput): boolean {
+  function showError(key: keyof EventFormState): boolean {
     return submitAttempted && !!errors[key];
   }
 

--- a/app/services/eventService.ts
+++ b/app/services/eventService.ts
@@ -1,14 +1,22 @@
-// Firestore write service for the `events` collection.
+// Firestore read/write service for the `events` collection.
 // Schema and field rationale: docs/DATA_SCHEMA.md.
 //
-// Validation duplicates AddEventModal on purpose: the form fails fast for
-// the UI; the service is the last line of defense for any caller (tests,
-// scripts, future code) that bypasses the form.
+// addEvent — A3. Validation duplicates AddEventModal on purpose: the form
+// fails fast for the UI; the service is the last line of defense for any
+// caller (tests, scripts, future code) that bypasses the form.
+//
+// getActiveEvents — A4. `endTime` IS the expiresAt field per the schema
+// doc; querying it directly avoids the drift a mirror field would silently
+// introduce.
 import {
   Timestamp,
   addDoc,
   collection,
+  getDocs,
+  orderBy,
+  query,
   serverTimestamp,
+  where,
 } from "firebase/firestore";
 import { auth, db } from "../utils/firebase";
 
@@ -19,6 +27,16 @@ const DESC_MAX = 500;
 const CLUB_MAX = 60;
 
 export type EventInput = {
+  title: string;
+  description: string;
+  location: string;
+  clubName: string;
+  startTime: Date;
+  endTime: Date;
+};
+
+export type ActiveEvent = {
+  id: string;
   title: string;
   description: string;
   location: string;
@@ -71,4 +89,25 @@ export async function addEvent(input: EventInput): Promise<string> {
     createdBy: auth.currentUser?.uid ?? null,
   });
   return docRef.id;
+}
+
+export async function getActiveEvents(): Promise<ActiveEvent[]> {
+  const q = query(
+    collection(db, COLLECTION),
+    where("endTime", ">", Timestamp.now()),
+    orderBy("endTime", "asc"),
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      title: data.title,
+      description: data.description,
+      location: data.location,
+      clubName: data.clubName,
+      startTime: (data.startTime as Timestamp).toDate(),
+      endTime: (data.endTime as Timestamp).toDate(),
+    };
+  });
 }

--- a/app/services/eventService.ts
+++ b/app/services/eventService.ts
@@ -1,0 +1,74 @@
+// Firestore write service for the `events` collection.
+// Schema and field rationale: docs/DATA_SCHEMA.md.
+//
+// Validation duplicates AddEventModal on purpose: the form fails fast for
+// the UI; the service is the last line of defense for any caller (tests,
+// scripts, future code) that bypasses the form.
+import {
+  Timestamp,
+  addDoc,
+  collection,
+  serverTimestamp,
+} from "firebase/firestore";
+import { auth, db } from "../utils/firebase";
+
+const COLLECTION = "events";
+
+const TITLE_MAX = 80;
+const DESC_MAX = 500;
+const CLUB_MAX = 60;
+
+export type EventInput = {
+  title: string;
+  description: string;
+  location: string;
+  clubName: string;
+  startTime: Date;
+  endTime: Date;
+};
+
+function validate(input: EventInput): string | null {
+  const title = input.title.trim();
+  if (!title) return "Title is required.";
+  if (title.length > TITLE_MAX) return `Title must be ${TITLE_MAX} characters or fewer.`;
+
+  const description = input.description.trim();
+  if (!description) return "Description is required.";
+  if (description.length > DESC_MAX) return `Description must be ${DESC_MAX} characters or fewer.`;
+
+  // TODO(brandon): once D3 ships app/constants/locations.ts, also assert
+  // location is a known LOCATIONS key. Until then, non-empty is the bar.
+  if (!input.location.trim()) return "Location is required.";
+
+  const clubName = input.clubName.trim();
+  if (!clubName) return "Club name is required.";
+  if (clubName.length > CLUB_MAX) return `Club name must be ${CLUB_MAX} characters or fewer.`;
+
+  if (!(input.startTime instanceof Date) || isNaN(input.startTime.getTime())) {
+    return "Start time is invalid.";
+  }
+  if (!(input.endTime instanceof Date) || isNaN(input.endTime.getTime())) {
+    return "End time is invalid.";
+  }
+  if (input.endTime.getTime() <= input.startTime.getTime()) {
+    return "End time must be after start time.";
+  }
+  return null;
+}
+
+export async function addEvent(input: EventInput): Promise<string> {
+  const error = validate(input);
+  if (error) throw new Error(error);
+
+  const docRef = await addDoc(collection(db, COLLECTION), {
+    title: input.title.trim(),
+    description: input.description.trim(),
+    location: input.location.trim(),
+    clubName: input.clubName.trim(),
+    startTime: Timestamp.fromDate(input.startTime),
+    endTime: Timestamp.fromDate(input.endTime),
+    createdAt: serverTimestamp(),
+    createdBy: auth.currentUser?.uid ?? null,
+  });
+  return docRef.id;
+}

--- a/docs/TEAM_TASKS.md
+++ b/docs/TEAM_TASKS.md
@@ -38,9 +38,9 @@ Branch: `feature/brandon/firebase-backend`
 - [x] **A1** `app/utils/firebase.ts` — initialize Firebase JS SDK from `.env`
 - [x] **A2** Firestore schema for `events` collection (document in
       `docs/DATA_SCHEMA.md`)
-- [ ] **A3** `app/services/eventService.ts` — `addEvent()` wired into the
+- [x] **A3** `app/services/eventService.ts` — `addEvent()` wired into the
       Add Event modal in `app/index.tsx`
-- [ ] **A4** `getActiveEvents()` filters by `expiresAt > now`
+- [x] **A4** `getActiveEvents()` filters by `expiresAt > now`
 - [ ] **A5** Replace strict text date inputs with
       `@react-native-community/datetimepicker`
 - [ ] **A6** Jest tests for `addEvent` (valid + invalid) and


### PR DESCRIPTION
Closes #6
Closes #7

## Summary

- **A3 — `addEvent`** in new `app/services/eventService.ts`. Writes to the `events` collection with the fields documented in `docs/DATA_SCHEMA.md` (`title`, `description`, `location`, `clubName`, `startTime`, `endTime`, server `createdAt`, `createdBy` from `auth.currentUser?.uid ?? null`).
- **AddEventModal swap** — the `addEventStub` in `app/components/AddEventModal.tsx` is gone; the modal imports the real `addEvent`, converts the form's string dates to `Date` at the submit boundary, and renames its internal type to `EventFormState` so `EventInput` (Date-typed) is the public service shape.
- **A4 — `getActiveEvents`** in the same service. Queries `where("endTime", ">", Timestamp.now())`, `orderBy("endTime", "asc")`, maps Firestore `Timestamp` back to JS `Date`. Returns `ActiveEvent[]` — a superset of `EventList`'s existing shape so Talan's B5 swap is a one-line change.

### Schema decisions worth flagging

- **No separate `expiresAt` field.** The schema doc that landed in A2 explicitly argues against a mirror field — `endTime` IS the expiry. Two fields for one concept silently drift; one field is enforced in Firestore.
- **No `isApproved` field.** No moderation flow exists yet, no UI reads the flag, planned security rules don't check it. Add it when there's a real approval path.
- **Service-level validation duplicates the form** (length caps, non-empty, `endTime > startTime`). Defense in depth for non-form callers (tests, future scripts).

## Test plan

- [ ] `npm run lint` clean (verified locally — only the pre-existing `pinDetails.tsx` warning remains)
- [ ] `npx expo start` → press `w` → no red overlay, no console errors
- [ ] Open the Add Event form, submit a valid event, confirm doc appears in the Firebase console with `endTime` as a `Timestamp`
- [ ] Submit invalid forms (empty title, end before start) — service rejects with a readable message
- [ ] Call `getActiveEvents()` from a test screen / temp button, confirm it returns the new event
- [ ] Manually edit one event's `endTime` to a past time in the Firebase console, confirm it stops appearing

A5 (datetimepicker) and A6 (Jest tests) are follow-up PRs.