### PR TITLE
fix: restore .env.example + sync D1/D2/D3 checkboxes after #32

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and fill in real values from your Firebase project.
+# Anything prefixed EXPO_PUBLIC_ is exposed to the client bundle (Expo
+# convention) — that is fine for Firebase Web config keys, which are not
+# secrets, but DO NOT put admin SDK credentials here.
+#
+# Get these from Firebase Console → Project Settings → General → Your apps
+# → Web app → SDK setup and configuration → Config.
+
+EXPO_PUBLIC_FIREBASE_API_KEY=
+EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=
+EXPO_PUBLIC_FIREBASE_PROJECT_ID=
+EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+EXPO_PUBLIC_FIREBASE_APP_ID=

--- a/docs/TEAM_TASKS.md
+++ b/docs/TEAM_TASKS.md
@@ -98,11 +98,11 @@ README with screenshots.
 
 Branch: `feature/matt/pins-integration`
 
-- [ ] **D1** Audit current pins in `app/index.tsx`, write
+- [x] **D1** Audit current pins in `app/index.tsx`, write
       `docs/pins_list.txt` (PinID | Location | x | y | Notes)
-- [ ] **D2** Add 5–10 missing campus pins (Student Union, Love Library,
+- [x] **D2** Add 5–10 missing campus pins (Student Union, Love Library,
       GMCS, ENS, Viejas, etc.) — aim for 10–15 total
-- [ ] **D3** `app/constants/locations.ts` — shared `LOCATIONS` map so pin
+- [x] **D3** `app/constants/locations.ts` — shared `LOCATIONS` map so pin
       labels and Firestore `location` strings always match
 - [ ] **D4** Integration merge: Brandon → Talan → Matt → Bryan, run
       `npx expo start` after each merge


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #32:

1. **Restore `.env.example`** — Matt's PR inadvertently deleted it
   (likely from an IDE `git rm` or stale local state). README still
   tells contributors `Copy-Item .env.example .env` for Firebase setup,
   so master shipping without it would break the documented onboarding
   flow. Restored verbatim from `05865a9:.env.example` — zero content
   change vs the version that's been in the project since Track A.

2. **Tick D1/D2/D3 boxes** in `docs/TEAM_TASKS.md`. Matt's PR landed
   the work but didn't sync the checkboxes. R6-clean: every changed
   line is a checkbox state change.

## Verification

- `git diff` on `docs/TEAM_TASKS.md`: 3 lines, all `- [ ]` → `- [x]`
- `.env.example` byte-identical to pre-deletion (624 bytes, same SHA)

Refs #17 #18 #19 #24
