### PR TITLE
fix(pins): correct inaccurate pin coordinates (ENS first; 10 more tracked in #42)

### DIFF
--- a/app/constants/locations.ts
+++ b/app/constants/locations.ts
@@ -87,7 +87,7 @@ export const LOCATIONS: Record<LocationId, Location> = {
   ENS: {
     id: 'ENS',
     name: 'Exercise & Nutritional Sciences (ENS)',
-    x: 0.45,
+    x: 0.42,
     y: 0.42,
   },
   LOVE_LIBRARY: {


### PR DESCRIPTION
## Summary

Corrects fractional `(x, y)` coordinates in `app/constants/locations.ts` for pins Bryan flagged as visually inaccurate. The coordinate system, type signatures, `LocationId` keys, and `id` strings are unchanged (Firestore contract preserved).

**Scope is partial**: Bryan supplied an explicit shift only for `ENS` ("slightly left"). For the other 10 flagged pins he has not yet supplied corrected coordinates or a labelled reference map. Per the review-and-merge agent's SA5 fallback rule, this PR ships the ENS fix now and the remaining 10 will land as follow-up commits on this branch (or a successor branch) once Bryan provides targets. See **#42** for the full checklist.

## Pins changed in this PR

| Pin   | Field | Old   | New   | Δ      | Rationale                                  |
|-------|-------|-------|-------|--------|--------------------------------------------|
| ENS   | x     | 0.45  | 0.42  | −0.03  | "slightly left" per Bryan, 2026-05-11      |

`ENS.y` (0.42) unchanged. `ENS.id`, `ENS.name`, all comments, and ordering unchanged.

## Pins intentionally NOT changed in this PR

- `LOVE_LIBRARY` — not on Bryan's inaccurate list; reviewed and stays at `(0.56, 0.47)`.
- `GMCS`, `EBA`, `ADAMS_HUMANITIES`, `VIEJAS_ARENA`, `STORM_HALL`, `PSFA`, `HARDY_TOWER`, `HEPNER_HALL`, `STUDENT_UNION`, `MANCHESTER_HALL` — flagged inaccurate but no target coordinates supplied yet. Tracked in #42.

## Validation

- `npx tsc --noEmit`: **0 errors** (matches master baseline of 0).
- `LOCATIONS` entries: **12** keys, all 12 `LocationId` union members still present (verified by `Select-String '^\s{2}[A-Z_]+:\s*\{'` count = 12, and `^\s*\|\s*'[A-Z_]+'` count = 12).
- New ENS `x` value `0.42` is in `[0, 1]` with 2 decimals (matches the file's convention).
- Diff is exactly one line:

  ```diff
  -    x: 0.45,
  +    x: 0.42,
  ```

  inside the `ENS` block; no other lines, no whitespace drift, no `id`/`name`/`notes` touched.

## Aspect-ratio note

The campus map asset Brandon proposes in #40 (2641×1755, ratio 1.5048) matches the 2600×1727 / 1.5055 documented in `locations.ts` within 0.05% — so this ENS shift, and any future shifts on the same branch, will remain valid once the high-res asset lands.

Refs #42
