### PR TITLE
Fix: Add Event feedback on web + pin positioning on resize

### DIFF
--- a/app/components/AddEventModal.tsx
+++ b/app/components/AddEventModal.tsx
@@ -6,7 +6,6 @@
 import { createElement, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   Modal,
   Platform,
@@ -20,6 +19,7 @@ import {
 import { LOCATION_LIST, type LocationId } from "../constants/locations";
 import { addEvent } from "../services/eventService";
 import { colors, radius, spacing, tap, typography } from "../constants/theme";
+import { firebaseReady } from "../utils/firebase";
 
 // @react-native-community/datetimepicker has no web implementation. Loading
 // it via require behind a Platform check keeps the web bundle clean.
@@ -96,6 +96,7 @@ export default function AddEventModal({ visible, onClose }: Props) {
   const [errors, setErrors] = useState<FieldErrors>({});
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [submitResult, setSubmitResult] = useState<{ type: "success" | "error"; msg: string } | null>(null);
 
   // Avoid setState after unmount when the user dismisses mid-submit.
   const mountedRef = useRef(true);
@@ -116,6 +117,7 @@ export default function AddEventModal({ visible, onClose }: Props) {
     setForm(EMPTY_FORM);
     setErrors({});
     setSubmitAttempted(false);
+    setSubmitResult(null);
   }
 
   function handleCancel() {
@@ -127,6 +129,7 @@ export default function AddEventModal({ visible, onClose }: Props) {
   async function handleSubmit() {
     if (submitting) return;
     setSubmitAttempted(true);
+    setSubmitResult(null);
     const next = validate(form);
     setErrors(next);
     if (Object.keys(next).length > 0) return;
@@ -143,13 +146,17 @@ export default function AddEventModal({ visible, onClose }: Props) {
         endTime: form.endTime!,
       });
       if (!mountedRef.current) return;
-      Alert.alert("Event added", "Your event has been posted.");
-      reset();
-      onClose();
+      setSubmitResult({ type: "success", msg: "Event added! Your event has been posted." });
+      // Brief delay so the user sees the success message before the modal closes.
+      setTimeout(() => {
+        if (!mountedRef.current) return;
+        reset();
+        onClose();
+      }, 1200);
     } catch (e: unknown) {
       if (!mountedRef.current) return;
       const msg = e instanceof Error ? e.message : String(e);
-      Alert.alert("Could not add event", msg);
+      setSubmitResult({ type: "error", msg });
     } finally {
       if (mountedRef.current) setSubmitting(false);
     }
@@ -208,6 +215,39 @@ export default function AddEventModal({ visible, onClose }: Props) {
               <Text style={{ ...typography.h2, color: colors.neutral600 }}>×</Text>
             </Pressable>
           </View>
+
+          {!firebaseReady && (
+            <View style={{
+              backgroundColor: "#FFF3CD",
+              borderRadius: radius.md,
+              padding: spacing.md,
+              marginBottom: spacing.md,
+              borderWidth: 1,
+              borderColor: "#FFECB5",
+            }}>
+              <Text style={{ ...typography.caption, color: "#664D03" }}>
+                Firebase is not configured. Events cannot be saved. Copy .env.example to .env and add your Firebase keys.
+              </Text>
+            </View>
+          )}
+
+          {submitResult && (
+            <View style={{
+              backgroundColor: submitResult.type === "success" ? "#D1E7DD" : "#F8D7DA",
+              borderRadius: radius.md,
+              padding: spacing.md,
+              marginBottom: spacing.md,
+              borderWidth: 1,
+              borderColor: submitResult.type === "success" ? "#BADBCC" : "#F5C2C7",
+            }}>
+              <Text style={{
+                ...typography.caption,
+                color: submitResult.type === "success" ? "#0F5132" : "#842029",
+              }}>
+                {submitResult.msg}
+              </Text>
+            </View>
+          )}
 
           <ScrollView
             keyboardShouldPersistTaps="handled"
@@ -280,27 +320,30 @@ export default function AddEventModal({ visible, onClose }: Props) {
             </Pressable>
             <Pressable
               onPress={handleSubmit}
-              disabled={submitting}
+              disabled={submitting || !firebaseReady}
               accessibilityRole="button"
               accessibilityLabel="Submit new event"
-              accessibilityState={{ busy: submitting, disabled: submitting }}
+              accessibilityState={{ busy: submitting, disabled: submitting || !firebaseReady }}
               style={({ pressed }) => ({
                 flex: 1,
                 minHeight: tap.minSize,
                 borderRadius: radius.md,
-                backgroundColor: submitting
-                  ? colors.scarletDark
-                  : pressed
+                backgroundColor: !firebaseReady
+                  ? colors.neutral300
+                  : submitting
                     ? colors.scarletDark
-                    : colors.scarlet,
+                    : pressed
+                      ? colors.scarletDark
+                      : colors.scarlet,
                 alignItems: "center",
                 justifyContent: "center",
                 flexDirection: "row",
                 gap: spacing.sm,
+                opacity: !firebaseReady ? 0.6 : 1,
               })}
             >
               {submitting && <ActivityIndicator color={colors.scarletInk} />}
-              <Text style={{ ...typography.button, color: colors.scarletInk }}>
+              <Text style={{ ...typography.button, color: !firebaseReady ? colors.neutral600 : colors.scarletInk }}>
                 {submitting ? "Adding…" : "Add Event"}
               </Text>
             </Pressable>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -77,7 +77,28 @@ export default function Index() {
     setSideMenuVis(true);
   };
 
-  // Pin marker visual size as fraction of map dims.
+  // Compute the actual rendered image size within the container.
+  // The image uses contentFit="contain", so it fits within (mapWidth × mapHeight)
+  // while preserving its aspect ratio. Pins must be positioned relative to
+  // the rendered image, not the full container, or they drift on resize.
+  const MAP_ASPECT = 2641 / 1755; // intrinsic image width / height
+  const containerAspect = mapWidth / (mapHeight || 1);
+  let imgW: number, imgH: number, imgOffsetX: number, imgOffsetY: number;
+  if (containerAspect > MAP_ASPECT) {
+    // Container is wider than the image — image fills height, letterboxed horizontally.
+    imgH = mapHeight;
+    imgW = mapHeight * MAP_ASPECT;
+    imgOffsetX = (mapWidth - imgW) / 2;
+    imgOffsetY = 0;
+  } else {
+    // Container is taller than the image — image fills width, letterboxed vertically.
+    imgW = mapWidth;
+    imgH = mapWidth / MAP_ASPECT;
+    imgOffsetX = 0;
+    imgOffsetY = (mapHeight - imgH) / 2;
+  }
+
+  // Pin marker visual size as fraction of rendered image dims.
   const PIN_W = 0.045;
   const PIN_H = 0.075;
 
@@ -154,10 +175,10 @@ export default function Index() {
             accessibilityLabel={`Open details for ${loc.name}`}
             style={{
               position: "absolute",
-              top: mapHeight * loc.y - (mapHeight * PIN_H) / 2,
-              left: mapWidth * loc.x - (mapWidth * PIN_W) / 2,
-              width: mapWidth * PIN_W,
-              height: mapHeight * PIN_H,
+              top: imgOffsetY + imgH * loc.y - (imgH * PIN_H) / 2,
+              left: imgOffsetX + imgW * loc.x - (imgW * PIN_W) / 2,
+              width: imgW * PIN_W,
+              height: imgH * PIN_H,
               zIndex: 999,
             }}
             hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}


### PR DESCRIPTION
## Summary

Fixes two issues: (1) clicking "Add Event" appeared to do nothing because `Alert.alert` is unreliable on web, and (2) pins drifted off their landmarks when the browser window was resized.

## Changes

### Add Event feedback
- Replaced `Alert.alert` with an inline success/error banner inside the modal so the user always sees what happened
- Added a warning banner when Firebase is not configured, explaining that events can't be saved without `.env`
- Disabled the submit button when Firebase is not configured (greyed out)

### Pin positioning
- The map image uses `contentFit="contain"`, so it letterboxes inside its container when the aspect ratio doesn't match
- Pins were positioned relative to the full container (`mapWidth × mapHeight`), causing them to drift off landmarks on resize
- Now computes the actual rendered image bounds (accounting for letterboxing) and positions pins relative to the image

## Test plan
- [x] `npm test` — 17 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Open Add Event without `.env` — warning banner visible, submit button disabled
- [ ] Open Add Event with `.env`, fill form, submit — inline success banner appears, event shows in list
- [ ] Submit with missing fields — validation errors appear on the relevant fields
- [ ] Resize browser window — pins stay anchored to their campus locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)